### PR TITLE
KAIZEN-0: Integrasjontestene rydder DB manuelt

### DIFF
--- a/src/test/java/no/nav/fo/veilarbdirigent/config/DatabaseTestContext.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/config/DatabaseTestContext.java
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbdirigent.db;
+package no.nav.fo.veilarbdirigent.config;
 
 import io.vavr.control.Option;
 import no.nav.dialogarena.config.fasit.DbCredentials;

--- a/src/test/java/no/nav/fo/veilarbdirigent/config/IntegrasjonsTest.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/config/IntegrasjonsTest.java
@@ -1,6 +1,5 @@
 package no.nav.fo.veilarbdirigent.config;
 
-import no.nav.fo.veilarbdirigent.db.DatabaseTestContext;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.BeforeAll;
 

--- a/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/Cleanup.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/Cleanup.java
@@ -1,0 +1,7 @@
+package no.nav.fo.veilarbdirigent.config.databasecleanup;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public interface Cleanup {
+    JdbcTemplate getJdbc();
+}

--- a/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/FeedMetadataCleanup.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/FeedMetadataCleanup.java
@@ -1,0 +1,11 @@
+package no.nav.fo.veilarbdirigent.config.databasecleanup;
+
+import org.junit.jupiter.api.AfterEach;
+
+public interface FeedMetadataCleanup extends Cleanup {
+
+    @AfterEach
+    default void deleteFeedMetadata() {
+        getJdbc().update("UPDATE FEED_METADATA SET NYE_BRUKERE_FEED_SISTE_ID = 0");
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/TaskCleanup.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/config/databasecleanup/TaskCleanup.java
@@ -1,0 +1,11 @@
+package no.nav.fo.veilarbdirigent.config.databasecleanup;
+
+import org.junit.jupiter.api.AfterEach;
+
+public interface TaskCleanup extends Cleanup {
+
+    @AfterEach
+    default void deleteTestData() {
+        getJdbc().update("DELETE FROM TASK");
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbdirigent/core/CoreIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/core/CoreIntegrationTest.java
@@ -6,6 +6,7 @@ import no.nav.fo.veilarbdirigent.config.AbstractIntegrationTest;
 import no.nav.fo.veilarbdirigent.config.CoreConfig;
 import no.nav.fo.veilarbdirigent.config.DAOConfig;
 import no.nav.fo.veilarbdirigent.config.DbConfig;
+import no.nav.fo.veilarbdirigent.config.databasecleanup.TaskCleanup;
 import no.nav.fo.veilarbdirigent.coreapi.Actuator;
 import no.nav.fo.veilarbdirigent.coreapi.MessageHandler;
 import no.nav.fo.veilarbdirigent.coreapi.Status;
@@ -23,7 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class CoreIntegrationTest extends AbstractIntegrationTest {
+class CoreIntegrationTest extends AbstractIntegrationTest implements TaskCleanup {
 
     private Core core = getBean(Core.class);
     private TaskDAO dao = getBean(TaskDAO.class);

--- a/src/test/java/no/nav/fo/veilarbdirigent/dao/TaskDAOTest.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/dao/TaskDAOTest.java
@@ -3,6 +3,7 @@ package no.nav.fo.veilarbdirigent.dao;
 import io.vavr.collection.List;
 import no.nav.fo.veilarbdirigent.TestUtils;
 import no.nav.fo.veilarbdirigent.config.IntegrasjonsTest;
+import no.nav.fo.veilarbdirigent.config.databasecleanup.TaskCleanup;
 import no.nav.fo.veilarbdirigent.coreapi.Status;
 import no.nav.fo.veilarbdirigent.coreapi.Task;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-class TaskDAOTest extends IntegrasjonsTest {
+class TaskDAOTest extends IntegrasjonsTest implements TaskCleanup {
 
     private TaskDAO dao = getBean(TaskDAO.class);
 

--- a/src/test/java/no/nav/fo/veilarbdirigent/input/feed/FeedDAOTest.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/input/feed/FeedDAOTest.java
@@ -1,6 +1,7 @@
 package no.nav.fo.veilarbdirigent.input.feed;
 
 import no.nav.fo.veilarbdirigent.config.IntegrasjonsTest;
+import no.nav.fo.veilarbdirigent.config.databasecleanup.FeedMetadataCleanup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +9,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
 @DisplayName("FeedDAO")
-class FeedDAOTest extends IntegrasjonsTest {
+class FeedDAOTest extends IntegrasjonsTest implements FeedMetadataCleanup{
     private FeedDAO dao = getBean(FeedDAO.class);
 
     @Test

--- a/src/test/java/no/nav/fo/veilarbdirigent/input/feed/OppfolgingFeedServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbdirigent/input/feed/OppfolgingFeedServiceTest.java
@@ -35,7 +35,7 @@ class OppfolgingFeedServiceTest {
     );
 
     @Test
-    void submits_the_recived_message_to_the_core() {
+    void submits_the_received_message_to_the_core() {
         oppfolgingFeedService.compute("dosn't matter", List.of(elements.head()));
         verify(core).submit(elements.head());
     }
@@ -47,7 +47,7 @@ class OppfolgingFeedServiceTest {
     }
 
     @Test
-    void tells_feedDao_to_update_last_recived_id_to_the_last_element_in_the_feed() {
+    void tells_feedDab_to_update_last_received_id_to_the_last_element_in_the_feed() {
         oppfolgingFeedService.compute("dosn't matter", elements);
         verify(feedDao).oppdaterSisteKjenteId(elements.last().getId());
     }


### PR DESCRIPTION
Opp til hver enkel integrasjontest å rydde opp DB-en etter seg.

Refaktorerte koden slik at det skal være lett å bare legge
til de ulike interfaceene for å rydde opp de ulike tabellene
testen har brukt