### PR TITLE
Ta i bruk veilarbregistrering i gcp i dev

### DIFF
--- a/src/main/java/no/nav/veilarbdirigent/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbdirigent/config/ClientConfig.java
@@ -26,9 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import java.io.IOException;
 
 import static no.nav.common.utils.EnvironmentUtils.isDevelopment;
-import static no.nav.common.utils.EnvironmentUtils.requireClusterName;
-import static no.nav.common.utils.UrlUtils.createAppAdeoPreprodIngressUrl;
-import static no.nav.common.utils.UrlUtils.createAppAdeoProdIngressUrl;
+import static no.nav.common.utils.UrlUtils.*;
 
 @Configuration
 public class ClientConfig {
@@ -66,15 +64,16 @@ public class ClientConfig {
     @Bean
     public VeilarbregistreringClient veilarbregistreringClient(ServiceToServiceTokenProvider serviceToServiceTokenProvider) {
         String url = isDevelopment().orElse(false)
-                ? createAppAdeoPreprodIngressUrl("veilarbregistrering", getEnvironment())
+                ? createDevInternalIngressUrl("veilarbregistrering")
                 : createAppAdeoProdIngressUrl("veilarbregistrering");
+        String cluster = isDevelopment().orElse(false) ? "dev-gcp" : "prod-fss";
 
         return new VeilarbregistreringClientImpl(
                 url,
                 () -> serviceToServiceTokenProvider.getServiceToken(
                         "veilarbregistrering",
                         "paw",
-                        requireClusterName()
+                        cluster
                 )
         );
     }


### PR DESCRIPTION
veilarbregistrering er fortsatt ikke klar til bruk i gcp i prod, så bruker prod-fss-appen inntil videre.