### PR TITLE
Bruk veilarbregistrering i gcp i prod

### DIFF
--- a/src/main/java/no/nav/veilarbdirigent/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbdirigent/config/ClientConfig.java
@@ -66,8 +66,8 @@ public class ClientConfig {
         var appName = "veilarbregistrering";
         String url = isDevelopment().orElse(false)
                 ? joinPaths(createDevInternalIngressUrl(appName), appName)
-                : joinPaths(createProdInternalIngressUrl(appName), appName);
-        var cluster = isDevelopment().orElse(false) ? "dev-gcp" : "prod-fss";
+                : joinPaths(createProdInternalIngressUrl("veilarbregistrering-gcp"), appName);
+        var cluster = isDevelopment().orElse(false) ? "dev-gcp" : "prod-gcp";
         return new VeilarbregistreringClientImpl(
                 url,
                 () -> tokenClient.createMachineToMachineToken(scope("veilarbregistrering", "paw", cluster))


### PR DESCRIPTION
veilarbregistrering har en midlertidig ingress i prod, denne kommer til å bli endret neste uke når vi har fått all trafikk over og sletter fss-appen.

Vi vil flytte POST-kall for å registrere brukere mandag 16. januar. Frem til det migrerer vi data fra FSS til GCP løpende. Dersom dere merger denne før mandag, vær obs på at det vil det være opp til et par minutter forsinkelse på dataen i GCP. Migreringsjobben vår flytter data hvert 3. minutt, dvs at nye registreringer vil ligge tilgjengelig i GCP innen ~3 minutter. Etter flytten på mandag, vil ikke lenger fss-appen gi dere oppdatert data da vi ikke kommer til å replikere data tilbake til Oracle/FSS. Denne PR-en bør dermed gå ut i prod senest mandag :)