### PR TITLE
Legg til Dependabot-oppsett

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: monday
+      time: "07:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: monday
+      time: "07:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Dependabot-oppsett

Konfigurerer Dependabot med ukentlig schedule (mandag 07:00) og gruppering av minor- og patch-oppdateringer.

### Inkluderte pakke-økosystemer
Se `.github/dependabot.yml` for detaljer.